### PR TITLE
Add stubs for libsandbox

### DIFF
--- a/scripts/generate-all.sh
+++ b/scripts/generate-all.sh
@@ -32,7 +32,8 @@ mkdir -p "$out"
   /usr/lib/libcupsimage.2.dylib \
   /usr/lib/libcupsmime.1.dylib \
   /usr/lib/libcupsppdc.1.dylib \
-  /usr/lib/libXplugin.1.dylib
+  /usr/lib/libXplugin.1.dylib \
+  /usr/lib/libsandbox.1.dylib
 
 @out@/libexec/frameworks-tbd.sh -s "$sysroot" -o "$out"
 

--- a/stubs/10.12/usr/lib/libsandbox.1.tbd
+++ b/stubs/10.12/usr/lib/libsandbox.1.tbd
@@ -1,0 +1,16 @@
+--- !tapi-tbd-v2
+archs:           [ i386, x86_64 ]
+uuids:           [ 'i386: 1B39F909-257D-3490-82DC-1B2CD06D9CA8', 'x86_64: 9C428C49-9D9A-3F9F-9573-BF5202D1F933' ]
+platform:        macosx
+install-name:    '/usr/lib/libsandbox.1.dylib'
+exports:
+  - archs:           [ i386, x86_64 ]
+    symbols:         [ _SANDBOX_BUILD_ID, _sandbox_apply, _sandbox_apply_container, 
+                       _sandbox_compile_entitlements, _sandbox_compile_file, _sandbox_compile_named, 
+                       _sandbox_compile_string, _sandbox_container_paths_iterate_items, 
+                       _sandbox_create_params, _sandbox_free_params, _sandbox_free_profile, 
+                       _sandbox_inspect_pid, _sandbox_inspect_smemory, _sandbox_set_param, 
+                       _sandbox_set_trace_path, _sandbox_set_user_state_item, _sandbox_user_state_item_buffer_create, 
+                       _sandbox_user_state_item_buffer_destroy, _sandbox_user_state_item_buffer_send, 
+                       _sandbox_user_state_iterate_items ]
+...


### PR DESCRIPTION
Like the frameworks, the stubs only contain things used by nixpkgs. This usage was hidden inside qtwebengine, so I didn't see it when constructing the stubs. See https://github.com/NixOS/nixpkgs/pull/98541#issuecomment-730088650 