### PR TITLE
Update docs and scripts for framework names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ nixpkgs.
 
 ## Framework Names
 
-These are derived from nixpkgs and stored in this repository for
-consistency. To update:
+These are derived from nixpkgs for consistency. To update:
 
     nix run -f scripts -c update-framework-names -o scripts/framework-names.json
 

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 let
   drv = { stdenv, lib, makeWrapper, jq, yq, ruby, gnused, coreutils }: stdenv.mkDerivation {
-    name = "generate-all";
+    name = "darwin-stubs-tools";
     src = lib.sourceFilesBySuffices ./. [ ".sh" ".rb" ".json" ];
 
     nativeBuildInputs = [ makeWrapper ];
@@ -19,6 +19,9 @@ let
 
       makeWrapper $out/libexec/generate-all.sh $out/bin/generate-all \
         --prefix PATH : ${lib.makeBinPath [ jq yq gnused coreutils ]}
+      makeWrapper $out/libexec/update-framework-names.sh \
+        $out/bin/update-framework-names \
+        --prefix PATH : ${lib.makeBinPath [ coreutils ]}
     '';
   };
 in

--- a/scripts/update-framework-names.sh
+++ b/scripts/update-framework-names.sh
@@ -21,7 +21,7 @@ while getopts "o:" opt; do
   esac
 done
 
-cp "$(nix-build --no-out-link --expr '
+install -Dm a=r,u+w "$(nix-build --no-out-link --expr '
   let
     pkgs = import <nixpkgs> {};
   in


### PR DESCRIPTION
The README mentions the framework names JSON is included in the repo but it's not.

The update-framework-names command isn't wrapped so the command in the README can't be executed. I added a wrapper and renamed the derivation because it's more general than just `generate-all`.

I also changed `update-framework-names.sh` to change the permissions to be more in line with the permissions on the generated stubs (the user always has write permission). This makes overwriting and removing the file a little less annoying : )